### PR TITLE
Update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The [documentation](https://fresh.deno.dev/docs/introduction) is available on
 
 ## 🚀 Getting started
 
-Install the latest [Deno CLI](https://deno.land/) version.
+Install the latest [Deno CLI](https://deno.com/) version.
 
 You can scaffold a new project by running the Fresh init script. To scaffold a
 project run the following:

--- a/docs/latest/concepts/server-configuration.md
+++ b/docs/latest/concepts/server-configuration.md
@@ -167,7 +167,7 @@ The `basePath` is also applied to the `src` and `srcset` attribute of
 
 ## Server
 
-Now that Deno has stabilized [Deno.serve](https://deno.land/api?s=Deno.serve)
+Now that Deno has stabilized [Deno.serve](https://docs.deno.com/api/deno/~/Deno.serve)
 and Fresh has switched to using this API, all server configuration options are
 embedded in `server` inside the `FreshConfig`. The fully expanded set of
 parameters looks like this:

--- a/docs/latest/getting-started/create-a-project.md
+++ b/docs/latest/getting-started/create-a-project.md
@@ -55,6 +55,6 @@ respectively:
 Finally a **`static/`** folder is created that contains static files that are
 automatically served "as is". [Learn more about static files][static-files].
 
-[import-map]: https://docs.deno.com/runtime/manual/basics/import_maps
-[task-runner]: https://deno.land/manual/tools/task_runner
+[import-map]: https://docs.deno.com/runtime/fundamentals/modules
+[task-runner]: https://docs.deno.com/runtime/reference/cli/task
 [static-files]: ../concepts/static-files

--- a/docs/latest/getting-started/index.md
+++ b/docs/latest/getting-started/index.md
@@ -20,5 +20,5 @@ nice with Deno. Documentation for this can also be found
 [in the manual][manual-editors].
 
 [deno-deploy]: https://deno.com/deploy
-[manual-installation]: https://deno.land/manual/getting_started/installation
-[manual-editors]: https://deno.land/manual/getting_started/setup_your_environment
+[manual-installation]: https://docs.deno.com/runtime/getting_started/installation/
+[manual-editors]: https://docs.deno.com/runtime/getting_started/setup_your_environment/

--- a/docs/latest/getting-started/index.md
+++ b/docs/latest/getting-started/index.md
@@ -20,5 +20,5 @@ nice with Deno. Documentation for this can also be found
 [in the manual][manual-editors].
 
 [deno-deploy]: https://deno.com/deploy
-[manual-installation]: https://docs.deno.com/runtime/getting_started/installation/
-[manual-editors]: https://docs.deno.com/runtime/getting_started/setup_your_environment/
+[manual-installation]: https://docs.deno.com/runtime/getting_started/installation
+[manual-editors]: https://docs.deno.com/runtime/getting_started/setup_your_environment

--- a/docs/latest/getting-started/running-locally.md
+++ b/docs/latest/getting-started/running-locally.md
@@ -61,4 +61,4 @@ If you now visit http://localhost:8000, you can see the running project. Try
 change some of the text in `routes/index.tsx` and see how the page updates
 automatically when you save the file.
 
-[--watch]: https://deno.land/manual/getting_started/command_line_interface#watch-mode
+[--watch]: https://docs.deno.com/runtime/getting_started/command_line_interface/#watch-mode

--- a/init/src/init.ts
+++ b/init/src/init.ts
@@ -603,7 +603,7 @@ Started" guide here: https://fresh.deno.dev/docs/getting-started
 
 ### Usage
 
-Make sure to install Deno: https://deno.land/manual/getting_started/installation
+Make sure to install Deno: https://docs.deno.com/runtime/getting_started/installation
 
 Then start the project in development mode:
 


### PR DESCRIPTION
This commit updates several links from their current URLs to the ones that they now redirect to. Any instances of `deno.land/x` and `deno.land/std` were left alone to avoid messing with dependencies, although these links may be able to be changed to their JSR equivalents.